### PR TITLE
Improve webpack configuration

### DIFF
--- a/tiles/index.html
+++ b/tiles/index.html
@@ -12,7 +12,7 @@ and open the template in the editor.
         <link href="node_modules/leaflet/dist/leaflet.css" rel="stylesheet"/>
 	
         <!-- Mapbox GL -->
-        <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.14.3/mapbox-gl.css' rel='stylesheet' />
+        <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css' rel='stylesheet' />
         <style>
             body { margin:0; padding:0; }
             #map { position:absolute; top:0; bottom:0; width:100%; }
@@ -28,7 +28,6 @@ and open the template in the editor.
             }
         </style>
         <div id='map' class = "map"></div>
-        <script src="./dist/main.js"></script>
     </body>
 
 </html>

--- a/tiles/package.json
+++ b/tiles/package.json
@@ -4,9 +4,9 @@
   "description": "First package.json",
   "main": "ScriptChangeLayer.js",
   "scripts": {
-    "build": "webpack  --mode production",
-    "dev": "webpack --mode development",
-    "start": "webpack-dev-server --open",
+    "build": "webpack --mode production -p",
+    "dev": "webpack --mode development -d",
+    "start": "webpack-dev-server --mode development -d --open",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -34,6 +34,7 @@
     "eslint-plugin-import": "^2.9.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",
+    "html-webpack-plugin": "^3.0.7",
     "webpack": "^4.0.0",
     "webpack-cli": "^2.0.9",
     "webpack-dev-server": "^3.1.1"

--- a/tiles/webpack.config.js
+++ b/tiles/webpack.config.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   entry: './src/index.js',
@@ -6,6 +7,11 @@ module.exports = {
     filename: 'main.js',
     path: path.resolve(__dirname, 'dist')
   },
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: 'index.html'
+    })
+  ],
   devServer: {
     contentBase: '.',
     port : 8000


### PR DESCRIPTION
- use html-webpack-plugin to insert js bundke into index.html
- this allows using webpack-dev-server for live-rebuild
- adapt CLI invocations for dev/prod mode
  - prod has minification and no source maps
  - dev has no minification and source maps
  - `npm start` also has no minification and source maps (like dev)
- use correct version of mapbox-gl-js css (TODO: load css also through webpack)